### PR TITLE
SYS-826: Initial form and scaffolding

### DIFF
--- a/catstats/forms.py
+++ b/catstats/forms.py
@@ -1,0 +1,93 @@
+import calendar
+from datetime import datetime as dt
+from django import forms
+
+REPORTS = [
+	('01', '1: New titles by format & difficulty'), # was 01
+	('02', '2: National contributions by format'), # was 11
+	('03', '3: Authority contributions'), # was 06
+	('04', '4: Maintenance by format & difficulty'), # was 02
+	('05', '5: Maintenance (broad)'), # was 09
+	('06', '6: Maintenance (details'), # was 10
+]
+# From https://docs.library.ucla.edu/x/EilACw
+CAT_CENTERS = [
+	('clk', 'Clark Library'),
+	('eal', 'East Asian Library'),
+	('ethno', 'Ethnomusicology Archive'),
+	('ftva', 'Film and Television Archive'),
+	('iml', 'Instructional Media Lab'),
+	('law', 'Law Library'),
+	('lsc', 'Library Special Collections'),
+	('rams', 'RAMS'),
+	('ues', 'University Elementary School'),
+]
+
+# Years from 2007 to current year, in list of tuples for HTML form
+# Final value of range isn't included
+YEARS = [(y,y) for y in range(dt.now().year, 2006, -1)]
+
+# Number and first 3 letters of months, in list of tuples for HTML form
+MONTHS= [(m, calendar.month_name[m][0:3]) for m in range(1,13)]
+
+class CatStatsForm(forms.Form):
+	report_list = forms.ChoiceField(
+		choices=REPORTS,
+	)
+	# Cataloging center, from bib 962 $a
+	cat_center = forms.ChoiceField(
+		choices=CAT_CENTERS,
+	)
+	# Fiscal year wanted?
+	is_FY = forms.BooleanField(
+		required=False, initial=False, label='Use fiscal year?',
+	)
+	# Dates, from bib 962 $c, selected by yyyymm only
+	year = forms.ChoiceField(
+		choices=YEARS,
+	)
+	month = forms.ChoiceField(
+		choices=MONTHS,
+	)
+	# Cataloger's initials, from bib 962 $b
+	cataloger = forms.CharField(
+		widget=forms.TextInput(
+			attrs={
+				'size': 10,
+				'placeholder': 'Initials',
+			}
+		)
+	)
+	# MARC bib language code
+	language_code = forms.CharField(
+		widget=forms.TextInput(
+			attrs={
+				'size': 5,
+				'max_length': 3,
+				'placeholder': 'Code',
+			}
+		),
+	)
+	# MARC bib place code
+	place_code = forms.CharField(
+		widget=forms.TextInput(
+			attrs={
+				'size': 5,
+				'max_length': 3,
+				'placeholder': 'Code',
+			}
+		),
+	)
+	# MARC bib 962 $k, used for some projects
+	f962_k_code = forms.CharField(
+		widget=forms.TextInput(
+			attrs={
+				'size': 25,
+				'placeholder': '962 $k code',
+			}
+		),
+		label='962 $k code'
+	)
+
+
+

--- a/catstats/templates/catstats/base.html
+++ b/catstats/templates/catstats/base.html
@@ -1,0 +1,12 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <!-- Custom JS -->
+        <!-- <script src="{% static 'js/main.js' %}" defer></script> -->
+    </head>
+    <body>
+        {% block content %}
+        {% endblock %}
+    </body>
+</html>

--- a/catstats/templates/catstats/catstats.html
+++ b/catstats/templates/catstats/catstats.html
@@ -1,0 +1,12 @@
+{% extends 'catstats/base.html' %}
+
+{% block content %}
+<form name="run_report" method="POST" enctype="multipart/form-data">
+    {% csrf_token %}
+    <table>
+        {{ form.as_table }}
+    </table>
+    <br>
+    <button type="submit">Run report</button>
+</form>
+{% endblock %}

--- a/catstats/urls.py
+++ b/catstats/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('report', views.run_report, name='run_report'),
+]

--- a/catstats/views.py
+++ b/catstats/views.py
@@ -1,3 +1,10 @@
 from django.shortcuts import render
+from .forms import CatStatsForm
 
-# Create your views here.
+# Placeholderf for form in SYS-826; will be fleshed out via SYS-827
+def run_report(request):
+	if request.method == 'POST':
+		pass
+	else:
+		form = CatStatsForm()
+	return render(request, 'catstats/catstats.html', {'form': form})

--- a/project/urls.py
+++ b/project/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    #path('admin/', admin.site.urls),
+    path('', include('catstats.urls')),
 ]


### PR DESCRIPTION
This PR creates a form for users to select the report and parameters they want for cataloging statistics.  It also includes minimal scaffolding to support the form:
* A placeholder view, `run_report`
* Minimal unstyled templates to display the form
* Entries in project and app `urls.py` support routing

URL: [/report](http://127.0.0.1:8000/report)
