### PR TITLE
SYS-875: Build and push image to DockerHub

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -1,0 +1,28 @@
+name: Build for Docker Hub Cataloging Statistics
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  build_for_docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: uclalibrary/cataloging-statistics:latest


### PR DESCRIPTION
This PR adds a GitHub Actions script which builds and pushes an image to DockerHub on merge to `main`.