### PR TITLE
SYS-867: Initial helm chart for catstats app

### DIFF
--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -8,7 +8,7 @@
 ## Fake values are arbitrary and are OK for version control.
 ###
 
-# Used in lbs/lbs/settings.py
+# Used in settings.py
 DJANGO_DB_BACKEND=django.db.backends.postgresql_psycopg2
 DJANGO_DB_HOST=db
 DJANGO_DB_PORT=5432

--- a/.github/workflows/push_helm_chart.yml
+++ b/.github/workflows/push_helm_chart.yml
@@ -1,0 +1,37 @@
+---
+
+name: Push Helm Chart to ChartMuseum
+on: 
+  push:
+    paths:
+      - 'charts/**'
+      - '!charts/*-*-values.yaml'
+    branches:
+      - main
+
+jobs:
+  push_helm_chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code repo 
+        uses: actions/checkout@v3
+
+      - name: Install Helm 
+        uses: azure/setup-helm@v2.0
+        with:
+          version: 'latest'
+
+      - name: Install Helm ChartMuseum plugin
+        run: |
+          helm plugin install https://github.com/chartmuseum/helm-push
+      
+      - name: Add ChartMuseum repo 
+        run: |
+          helm repo add uclalibcm https://chartmuseum.library.ucla.edu
+      
+      - name: Push Helm Chart to ChartMuseum repo
+        env: 
+          HELM_REPO_USERNAME: ${{ secrets.CM_BASICAUTH_USERNAME }}
+          HELM_REPO_PASSWORD: ${{ secrets.CM_BASICAUTH_PASSWORD }}
+        run: |
+          helm cm-push charts/ uclalibcm

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ dmypy.json
 
 # Local secrets
 *secret*
+# But allow Helm secrets
+!secrets.yaml
+!externalsecret.yaml
 
 # Local static files collected when testing gunicorn and whitenoise
 staticfiles/

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Local secrets
 *secret*
+
+# Local static files collected when testing gunicorn and whitenoise
+staticfiles/

--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -21,3 +21,7 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Environment-specific Values files
+/test-catalogingstatistics-values.yaml
+/prod-catalogingstatistics-values.yaml

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "0.1"
+description: Chart for Cataloging Statistics application
+name: cataloging-statistics
+version: 0.0.1

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cataloging-statistics.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cataloging-statistics.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cataloging-statistics.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cataloging-statistics.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cataloging-statistics.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cataloging-statistics.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cataloging-statistics.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cataloging-statistics.labels" -}}
+helm.sh/chart: {{ include "cataloging-statistics.chart" . }}
+{{ include "cataloging-statistics.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cataloging-statistics.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cataloging-statistics.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}-configmap
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+data:
+  DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
+  DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}
+  DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
+  DJANGO_DB_BACKEND: {{ .Values.django.env.db_backend }}
+  DJANGO_DB_NAME: {{ .Values.django.env.db_name }}
+  DJANGO_DB_USER: {{ .Values.django.env.db_user }}
+  DJANGO_DB_HOST: {{ .Values.django.env.db_host }}
+  DJANGO_DB_PORT: {{ .Values.django.env.db_port | quote }}
+  DJANGO_LOG_LEVEL: {{ .Values.django.env.log_level }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cataloging-statistics.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cataloging-statistics.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "cataloging-statistics.fullname" . }}-configmap
+            - secretRef:
+                name: {{ include "cataloging-statistics.fullname" . }}-secrets
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /report
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+          readinessProbe:
+            httpGet:
+              path: /report
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ range .Values.django.env.allowed_hosts }}{{ . }}{{ end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}-externalsecret
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  refreshInterval: 10m
+  secretStoreRef:
+    name: systems-clustersecretstore
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "cataloging-statistics.fullname" . }}-secrets
+  data:
+    - secretKey: "DJANGO_SECRET_KEY"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.django_secret_key }}
+    - secretKey: "DJANGO_DB_PASSWORD"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.db_password }}
+    - secretKey: "ALMA_API_KEY"
+      remoteRef:
+        key: {{ .Values.django.externalSecrets.env.alma_api_key }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cataloging-statistics.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . | quote }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+     {{- end }}
+{{- end }}

--- a/charts/templates/namespace.yaml
+++ b/charts/templates/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cataloging-statistics{{ .Values.django.env.run_env }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{ if not .Values.django.externalSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}-secrets
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+{{ include "cataloging-statistics.fullname" . | indent 4 }}
+type: Opaque
+data:
+  DJANGO_SECRET_KEY: {{ randAlphaNum 20 | b64enc | quote }}
+  DJANGO_DB_PASSWORD: {{ .Values.django.env.db_password | b64enc | quote }}
+  ALMA_API_KEY: {{ .Values.django.env.alma_api_key | b64enc | quote }}
+{{ end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cataloging-statistics.fullname" . }}
+  namespace: cataloging-statistics{{ .Values.django.env.run_env }}
+  labels:
+    {{- include "cataloging-statistics.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.django.env.target_port | default "8000" }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cataloging-statistics.selectorLabels" . | nindent 4 }}

--- a/charts/test-catalogingstatistics-values.yaml
+++ b/charts/test-catalogingstatistics-values.yaml
@@ -1,0 +1,72 @@
+# Values for cataloging-statisticstest.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+cataloging-statistics:
+  replicaCount: 1
+
+  image:
+    repository: uclalibrary/cataloging-statistics
+    tag: latest
+    pullPolicy: Always
+
+  nameOverride: ""
+
+  fullnameOverride: ""
+
+  service:
+    type: NodePort
+    port: 80
+    
+  ingress:
+    enabled: "true"
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+      cert-manager.io/cluster-issuer: sectigo-acme-clusterissuer
+      kubernetes.io/tls-acme: "true"
+
+    hosts:
+      - host: 'catstats.library.ucla.edu'
+        paths:
+          - "/"
+    tls:
+    - secretName: cataloging-statistics-tls
+      hosts:
+        - catstats.library.ucla.edu
+
+  django:
+    env:
+      run_env: "test"
+      debug: "false"
+      allowed_hosts:
+        - catstats.library.ucla.edu
+      db_backend: "django.db.backends.postgresql_psycopg2"
+      db_name: "cataloging_stats"
+      db_user: "cataloging_stats"
+      db_host: "p-d-postgres.library.ucla.edu"
+      db_port: 5432
+      log_level: "INFO"
+
+    externalSecrets:
+      enabled: "true"
+      env:
+        # Application database used by django
+        db_password: "/systems/testsoftwaredev/cataloging-statisticstest/db_password"
+        django_secret_key: "/systems/testsoftwaredev/cataloging-statisticstest/django_secret_key"
+        alma_api_key: "/systems/testsoftwaredev/cataloging-statisticstest/alma_api_key"
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 250m
+      memory: 100Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,74 @@
+# Default values for cataloging-statistics.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: uclalibrary/cataloging-statistics
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+django:
+  env:
+    run_env: "prod"
+    debug: "false"
+    allowed_hosts: []
+    #  - localhost
+    #  - 127.0.0.1
+    #  - [::1]
+    db_backend: ""
+    db_name: ""
+    db_user: ""
+    db_host: ""
+    db_port: ""
+    # Include if externalSecrets enabled: "false"
+    #db_password: ""
+    log_level: ""
+
+  externalSecrets:
+    enabled: "false"
+    env: {}
+    # Include below if enabled: "true"
+    #  db_password: ""
+    #  django_secret_key: ""
+  
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+


### PR DESCRIPTION
This PR adds the initial Helm chart for the `cataloging-statistics` application.  
* Chart and values are within the application repository.
* Target environment is `test`.
* The three relevant secrets have been created.
* Docker image has been built and pushed to DockerHub.
* Minor tweaks to 2 non-chart files for consistency.

One possible blocker: The domain has not yet been created; see [SYS-876](https://jira.library.ucla.edu/browse/SYS-876),
