### PR TITLE
SYS-914: Fix CSRF error

### DIFF
--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -15,7 +15,7 @@ DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
 
 # Django 4 may require this, at least in our deployment environment.
 # Comma separated list (if multiple) of additional trusted hosts
-DJANGO_CSRF_TRUSTED_ORIGINS=https://dlcs-staff.library.ucla.edu
+DJANGO_CSRF_TRUSTED_ORIGINS=https://catstats.library.ucla.edu
 
 # DEBUG, INFO, WARNING, ERROR, CRITICAL
 DJANGO_LOG_LEVEL=INFO

--- a/.docker-compose_django.env
+++ b/.docker-compose_django.env
@@ -13,6 +13,10 @@ DJANGO_DEBUG=True
 # https://docs.djangoproject.com/en/4.0/ref/settings/#allowed-hosts
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
 
+# Django 4 may require this, at least in our deployment environment.
+# Comma separated list (if multiple) of additional trusted hosts
+DJANGO_CSRF_TRUSTED_ORIGINS=https://dlcs-staff.library.ucla.edu
+
 # DEBUG, INFO, WARNING, ERROR, CRITICAL
 DJANGO_LOG_LEVEL=INFO
 

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: Chart for Cataloging Statistics application
 name: cataloging-statistics
-version: 0.0.1
+version: 0.0.2

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -9,9 +9,11 @@ data:
   DJANGO_RUN_ENV: {{ .Values.django.env.run_env }}
   DJANGO_DEBUG: {{ .Values.django.env.debug | quote }}
   DJANGO_ALLOWED_HOSTS: {{ range .Values.django.env.allowed_hosts }}{{ . | quote }}{{ end }}
+  DJANGO_CSRF_TRUSTED_ORIGINS: {{ range .Values.django.env.csrf_trusted_origins }}{{ . | quote }}{{ end }}
   DJANGO_DB_BACKEND: {{ .Values.django.env.db_backend }}
   DJANGO_DB_NAME: {{ .Values.django.env.db_name }}
   DJANGO_DB_USER: {{ .Values.django.env.db_user }}
   DJANGO_DB_HOST: {{ .Values.django.env.db_host }}
   DJANGO_DB_PORT: {{ .Values.django.env.db_port | quote }}
   DJANGO_LOG_LEVEL: {{ .Values.django.env.log_level }}
+

--- a/charts/test-catalogingstatistics-values.yaml
+++ b/charts/test-catalogingstatistics-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/cataloging-statistics
-  tag: v0.9.5
+  tag: v0.9.6
   pullPolicy: Always
 
 nameOverride: ""
@@ -41,6 +41,8 @@ django:
     debug: "false"
     allowed_hosts:
       - catstats.library.ucla.edu
+    csrf_trusted_origins:
+      - https://catstats.library.ucla.edu
     db_backend: "django.db.backends.postgresql_psycopg2"
     db_name: "cataloging_stats"
     db_user: "cataloging_stats"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -37,6 +37,7 @@ django:
     #  - localhost
     #  - 127.0.0.1
     #  - [::1]
+    csrf_trusted_origins: []
     db_backend: ""
     db_name: ""
     db_user: ""

--- a/project/settings.py
+++ b/project/settings.py
@@ -30,6 +30,8 @@ DEBUG = os.getenv("DJANGO_DEBUG")
 # which is a string - but ALLOWED_HOSTS requires a list
 ALLOWED_HOSTS = list(os.getenv("DJANGO_ALLOWED_HOSTS").split(","))
 
+# Django 4 may require this, at least in our deployment environment.
+CSRF_TRUSTED_ORIGINS = list(os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS").split(","))
 
 # Application definition
 


### PR DESCRIPTION
This PR fixes Django's CSRF error, caused when nginx terminates TLS before the request gets to Django.
* Django config changes
* Added environment variable to control this
* Updated Chart version 
* Updated image tag
