### PR TITLE
LX-1447 - Prep for migrating cat stats app to Rancher testrke01 cluster

### DIFF
--- a/charts/templates/namespace.yaml
+++ b/charts/templates/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cataloging-statistics{{ .Values.django.env.run_env }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-failed

--- a/charts/test-catalogingstatistics-values.yaml
+++ b/charts/test-catalogingstatistics-values.yaml
@@ -14,7 +14,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
-  type: NodePort
+  type: ClusterIP
   port: 80
   
 ingress:
@@ -54,9 +54,9 @@ django:
     enabled: "true"
     env:
       # Application database used by django
-      db_password: "/systems/testsoftwaredev/cataloging-statisticstest/db_password"
-      django_secret_key: "/systems/testsoftwaredev/cataloging-statisticstest/django_secret_key"
-      alma_api_key: "/systems/testsoftwaredev/cataloging-statisticstest/alma_api_key"
+      db_password: "/systems/testrke01/cataloging-statisticstest/db_password"
+      django_secret_key: "/systems/testrke01/cataloging-statisticstest/django_secret_key"
+      alma_api_key: "/systems/testrke01/cataloging-statisticstest/alma_api_key"
 
 resources:
   limits:


### PR DESCRIPTION
* Remove namespace template from the chart because ArgoCD will handle this as a part of the deploy process
* Adjust the env specific values file to use: 
    * updated external secrets paths
    * Service type of `ClusterIP`