### PR TITLE
SYS-1670: Image and package upgrades

### DIFF
--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build_docker_hub.yml
+++ b/.github/workflows/build_docker_hub.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -31,8 +31,10 @@ jobs:
         run: echo "${{ steps.yaml-data.outputs.data }}"
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: uclalibrary/cataloging-statistics:${{ steps.yaml-data.outputs.data }}
+          tags: |
+            uclalibrary/cataloging-statistics:${{ steps.yaml-data.outputs.data }}
+            uclalibrary/cataloging-statistics:scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 # Debian repository management
 RUN apt-get update

--- a/charts/prod-catalogingstatistics-values.yaml
+++ b/charts/prod-catalogingstatistics-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/cataloging-statistics
-  tag: v1.0.3
+  tag: v1.0.4
   pullPolicy: Always
 
 nameOverride: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   django:
     build: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django == 4.2.11
-requests == 2.31.0
+Django == 4.2.16
+requests == 2.32.3
 xmltodict == 0.13.0
-psycopg2==2.9.2
-gunicorn==20.1.0
-whitenoise==6.0.0
+psycopg2==2.9.7
+gunicorn==23.0.0
+whitenoise==6.5.0


### PR DESCRIPTION
Implements [SYS-1670](https://uclalibrary.atlassian.net/browse/SYS-1670).  Updates version to `v1.0.4` for deployment.  There are no release notes for this application.

Includes these updates, with no functionality changes:
* Base image updated to use Debian 12 and Python 3.12
* Django updated to 4.2.16
  * `gunicorn` (23.0.0) and `requests` (2.32.3) also updated to address Dependabot alerts
  * `psycopg2` (2.9.7) and `whitenoise` (6.5.0) updated to match versions used by Terra
* Removed version declaration from docker-compose files
* `build_docker_hub` updated to use the latest versions of GitHub Actions components, and to add the scan tag to the Docker Hub build

### Testing

Confirm that the updated application builds and starts correctly, and that there are no errors in the new image build logs:
`docker compose --progress plain build > build.log`

There are no automated tests for this application 👎, so there's also no "build and test" action/check to review.

The [application](http://127.0.0.1:8000/) should show a basic form for running reports.  There is no admin interface or login for this.

Optional: if you want to try the application out, run this to load last month's data from Analytics (takes about a minute):
`docker compose exec django python manage.py refresh_analytics_data -m 202408`

You can then use the web interface to report on August 2024 data.


[SYS-1670]: https://uclalibrary.atlassian.net/browse/SYS-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ