### PR TITLE
SYS-1738: Fix form years

### DIFF
--- a/catstats/forms.py
+++ b/catstats/forms.py
@@ -24,10 +24,6 @@ CAT_CENTERS = [
     ("ues", "University Elementary School"),
 ]
 
-# Years from 2007 to current year, in list of tuples for HTML form
-# Final value of range isn't included
-YEARS = [(y, y) for y in range(dt.now().year, 2006, -1)]
-
 # Number and first 3 letters of months, in list of tuples for HTML form
 # Format m 1..12 as strings '01'..'12'
 MONTHS = [(str(m).zfill(2), calendar.month_name[m][0:3]) for m in range(1, 13)]
@@ -35,7 +31,21 @@ MONTHS = [(str(m).zfill(2), calendar.month_name[m][0:3]) for m in range(1, 13)]
 REPORT_PERIODS = [("ym", "Month only"), ("fy", "Fiscal year"), ("cy", "Calendar year")]
 
 
+def _get_years() -> list[tuple[int, int]]:
+    # Years from 2007 to current year, in list of tuples for HTML form
+    # Final value of range isn't included
+    return [(y, y) for y in range(dt.now().year, 2006, -1)]
+
+
 class CatStatsForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # This needs to be set in __init__() so that it is evaluated whenever
+        # the form is loaded. Otherwise, these values are calculated and set
+        # only at application start, and can be wrong if the application is not
+        # restarted when a new year begins.
+        self.fields["year"] = forms.ChoiceField(choices=_get_years())
+
     report = forms.ChoiceField(
         choices=REPORTS,
     )
@@ -43,10 +53,10 @@ class CatStatsForm(forms.Form):
     cat_center = forms.ChoiceField(
         choices=CAT_CENTERS,
     )
-    # Dates, from bib 962 $c, selected by yyyymm only
-    year = forms.ChoiceField(
-        choices=YEARS,
-    )
+    # Placeholder for year so it's positioned correctly;
+    # values are set in __init__().
+    year = forms.ChoiceField()
+    # year and month are combined for searching the bib 962 $c, selected by yyyymm only
     month = forms.ChoiceField(
         choices=MONTHS,
     )

--- a/charts/prod-catalogingstatistics-values.yaml
+++ b/charts/prod-catalogingstatistics-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/cataloging-statistics
-  tag: v1.0.4
+  tag: v1.0.5
   pullPolicy: Always
 
 nameOverride: ""


### PR DESCRIPTION
Fixes [SYS-1738](https://uclalibrary.atlassian.net/browse/SYS-1738). Bumps version to `v1.0.5` for deployment.

This PR fixes a bug which caused the list of years in the report generation form to not update correctly if the calendar year changed after the application started.  For example, if the application started in December 2024, the form's list of years did not automatically update to include 2025 on January 1, 2025.  This is because the list was calculated using the value of `datetime.now()` when the application started.

The fix moves the generation of the list of years to a method which is called whenever a new instance of the form is initialized, which happens every time the `run_report()` view is called (so, every time a user interacts with the application, basically).

I was not able to add test(s) for this fix.  I tried mocking `datetime.now()`, and was able to mock the behavior when generating the list of years within the test, but not when the list is generated via the form itself.  It also is not possible to test by manually changing the current date in the Docker container, as the container gets its date from the host, and I'm not willing to change my own machine's date (nor to add other complicated dependencies like [libfaketime](https://github.com/wolfcw/libfaketime) to the container).

It doesn't break anything... if you want to check, run `docker compose up -d`, visit http://127.0.0.1:8000/ , and observe that the "Year" list contains the current year, 2025 :)


[SYS-1738]: https://uclalibrary.atlassian.net/browse/SYS-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ