### PR TITLE
SYS-1748: Update Django to version 4.2.19 to patch security issues

### DIFF
--- a/catstats/templates/catstats/release_notes.html
+++ b/catstats/templates/catstats/release_notes.html
@@ -4,6 +4,14 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.7</h4>
+<p><i>February 26, 2025</i></p>
+<ul>
+    <li>
+        Update Django to version 4.2.19 to patch security issues.
+    </li>
+</ul>
+
 <h4>1.0.6</h4>
 <p><i>February 25, 2025</i></p>
 <ul>

--- a/charts/prod-catalogingstatistics-values.yaml
+++ b/charts/prod-catalogingstatistics-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/cataloging-statistics
-  tag: v1.0.6
+  tag: v1.0.7
   pullPolicy: Always
 
 nameOverride: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - .docker-compose_django.env
       - .docker-compose_db.env
       # Local development only
-      # - .docker-compose_secrets.env
+      - .docker-compose_secrets.env
     ports: 
       # Variables here must be set in environment, or in .env - not in any env_file
       - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - .docker-compose_django.env
       - .docker-compose_db.env
       # Local development only
-      - .docker-compose_secrets.env
+      # - .docker-compose_secrets.env
     ports: 
       # Variables here must be set in environment, or in .env - not in any env_file
       - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django == 4.2.16
+Django == 4.2.19
 requests == 2.32.3
 xmltodict == 0.13.0
 psycopg2==2.9.7


### PR DESCRIPTION
Implements [SYS-1748](https://uclalibrary.atlassian.net/browse/SYS-1748)

- Updated Django from 4.2.16 to 4.2.19 in `requirements.txt`
- Bumped version tag in Helm chart to 1.0.7
- Added release note to Django app template file
- Commented out secrets env file from `docker-compose.yml` to allow local Docker deployment

**Testing**
No automated tests for the Django app


[SYS-1748]: https://uclalibrary.atlassian.net/browse/SYS-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ