### PR TITLE
Upgrade Django and PostgreSQL

### DIFF
--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -9,7 +9,7 @@
 ###
 
 # Used in settings.py
-DJANGO_DB_BACKEND=django.db.backends.postgresql_psycopg2
+DJANGO_DB_BACKEND=django.db.backends.postgresql
 DJANGO_DB_HOST=db
 DJANGO_DB_PORT=5432
 DJANGO_DB_NAME=cataloging_stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 # Set correct timezone
 RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
-# Install dependencies needed to build psycopg2 python module
+# Install dependencies needed to build psycopg python module
 RUN apt-get install -y gcc python3-dev libpq-dev
 
 # Create django user and switch context to that user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 # Debian repository management
 RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The development database is PostgreSQL 16, to match our central production datab
 
 #### Django container
 
-This uses Django 5.2 LTS, which requires Python 3.10 or later; the container uses Python 3.12.
+This uses Django 5.2 LTS, which requires Python 3.10 or later; the container uses Python 3.13.
 It shouldn't matter what version of Python is used locally, as all code runs in the container.
 
 The container runs via `docker_scripts/entrypoint.sh`, which

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The development environment requires:
 
 #### PostgreSQL container
 
-The development database is PostgreSQL 12, to match our central production database environment.
+The development database is PostgreSQL 16, to match our central production database environment.
 
 #### Django container
 
-This uses Django 4.2, which requires Python 3.8 or later; the container uses Python 3.12.
+This uses Django 5.2 LTS, which requires Python 3.10 or later; the container uses Python 3.12.
 It shouldn't matter what version of Python is used locally, as all code runs in the container.
 
 The container runs via `docker_scripts/entrypoint.sh`, which

--- a/catstats/templates/catstats/release_notes.html
+++ b/catstats/templates/catstats/release_notes.html
@@ -4,6 +4,16 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.8</h4>
+<p><i>May 15, 2025</i></p>
+<ul>
+    <li>
+        Update Django to version 5.2.1.
+        Update Python to version 3.13.
+        Update psycopg to version 3.2.9 to go with PostgreSQL 16.
+    </li>
+</ul>
+
 <h4>1.0.7</h4>
 <p><i>February 26, 2025</i></p>
 <ul>

--- a/charts/prod-catalogingstatistics-values.yaml
+++ b/charts/prod-catalogingstatistics-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/cataloging-statistics
-  tag: v1.0.7
+  tag: v1.0.8
   pullPolicy: Always
 
 nameOverride: ""
@@ -43,7 +43,7 @@ django:
       - catstats.library.ucla.edu
     csrf_trusted_origins:
       - https://catstats.library.ucla.edu
-    db_backend: "django.db.backends.postgresql_psycopg2"
+    db_backend: "django.db.backends.postgresql"
     db_name: "cataloging_stats"
     db_user: "cataloging_stats"
     db_host: "p-d-postgres.library.ucla.edu"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 services:
   django:
     build: .
-    volumes: 
+    volumes:
       - .:/home/django/cataloging-statistics
     env_file:
       - .docker-compose_django.env
       - .docker-compose_db.env
       # Local development only
       - .docker-compose_secrets.env
-    ports: 
+    ports:
       # Variables here must be set in environment, or in .env - not in any env_file
       - "8000:8000"
     depends_on:
@@ -17,7 +17,7 @@ services:
       # For access to remote database via ssh tunnel on host
       - "host.docker.internal:host-gateway"
   db:
-    image: postgres:12
+    image: postgres:16
     env_file:
       - .docker-compose_db.env
     volumes:

--- a/docker_scripts/entrypoint.sh
+++ b/docker_scripts/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 
 # Check when database is ready for connections
 echo "Checking database connectivity..."
-until python -c 'import os, psycopg2 ; conn = psycopg2.connect(host=os.environ.get("DJANGO_DB_HOST"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
+until python -c 'import os, psycopg ; conn = psycopg.connect(host=os.environ.get("DJANGO_DB_HOST"),user=os.environ.get("DJANGO_DB_USER"),password=os.environ.get("DJANGO_DB_PASSWORD"),dbname=os.environ.get("DJANGO_DB_NAME"))' ; do
   echo "Database connection not ready - waiting"
   sleep 5
 done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django == 4.2.19
+Django == 5.2.1
 requests == 2.32.3
 xmltodict == 0.13.0
-psycopg2==2.9.7
+psycopg==3.2.9
 gunicorn==23.0.0
 whitenoise==6.5.0


### PR DESCRIPTION
Implements [SYS-1825](https://uclalibrary.atlassian.net/browse/SYS-1825)

This PR includes upgrades to Django, as well as to PostgreSQL as required by the new Django LTS version we're moving to. I made a few changes to the README to reflect the upgrades.

Upgrades:
* Django 4.2.19 -> 5.2.1
* psycopg 2.9.7 -> 3.2.9 (`psycopg` PIP package replaces `psycopg2`)
* PostgreSQL 14 -> 16

#### Upgrade compatibility check
I installed [django-upgrade](https://pypi.org/project/django-upgrade/) in my local instance and input all `*.py` files to it. It flagged no compatibility issues with the upgrade from Django 4.2 to 5.2 and made no code changes.

#### Tests
There are no existing unit tests for this project. I manually confirmed the application is available where it should be on `localhost` and ran the `refresh_analytics_data.py` script to fetch data from Alma. I was able to generate reports based on this data, so it appears both the upgraded application and database are working as expected locally.

[SYS-1825]: https://uclalibrary.atlassian.net/browse/SYS-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ