### PR TITLE
SYS-2012: security patches

### DIFF
--- a/catstats/templates/catstats/release_notes.html
+++ b/catstats/templates/catstats/release_notes.html
@@ -4,6 +4,14 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.9</h4>
+<p><i>September 22 2025</i></p>
+<ul>
+    <li>
+        Update Django to version 5.2.6 and requests to version 2.32.5.
+    </li>
+</ul>
+
 <h4>1.0.8</h4>
 <p><i>May 15, 2025</i></p>
 <ul>

--- a/charts/prod-catalogingstatistics-values.yaml
+++ b/charts/prod-catalogingstatistics-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/cataloging-statistics
-  tag: v1.0.8
+  tag: v1.0.9
   pullPolicy: Always
 
 nameOverride: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django == 5.2.1
-requests == 2.32.3
+Django == 5.2.6
+requests == 2.32.5
 xmltodict == 0.13.0
 psycopg==3.2.9
 gunicorn==23.0.0


### PR DESCRIPTION
Implements [SYS-2012](https://uclalibrary.atlassian.net/browse/SYS-2012)

Upgrades Django to 5.2.6 and requests to 2.32.5, addressing all current [dependabot alerts](https://github.com/UCLALibrary/cataloging-statistics/security/dependabot) for this repo.

Also includes release notes and tag bump for deployment.

This repo has no tests, so please build the container, reload data if needed (`docker compose exec django python manage.py refresh_analytics_data -m 202509`), and [check out the app in browser](http://127.0.0.1:8000/).

[SYS-2012]: https://uclalibrary.atlassian.net/browse/SYS-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ