### PR TITLE
SYS-2126: Update Django to 5.2.10 to patch security issues

### DIFF
--- a/catstats/templates/catstats/release_notes.html
+++ b/catstats/templates/catstats/release_notes.html
@@ -4,6 +4,14 @@
 <h3>Release Notes</h3>
 <hr/>
 
+<h4>1.0.11</h4>
+<p><i>January 6, 2026</i></p>
+<ul>
+    <li>
+        Update Django to version 5.2.10 to patch security issues.
+    </li>
+</ul>
+
 <h4>1.0.10</h4>
 <p><i>October 3, 2025</i></p>
 <ul>

--- a/charts/prod-catalogingstatistics-values.yaml
+++ b/charts/prod-catalogingstatistics-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: uclalibrary/cataloging-statistics
-  tag: v1.0.10
+  tag: v1.0.11
   pullPolicy: Always
 
 nameOverride: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django == 5.2.6
+Django == 5.2.10
 psycopg==3.2.9
 gunicorn==23.0.0
 whitenoise==6.5.0


### PR DESCRIPTION
Implements [SYS-2126](https://uclalibrary.atlassian.net/browse/SYS-2126)

Updates Django to 5.2.10 to patch security issues and resolve Dependabot alerts.

No tests for this project, so the app can be manually tested after reloading data from Alma Analytics:

`docker compose exec django python manage.py refresh_analytics_data -m 202512`

[SYS-2126]: https://uclalibrary.atlassian.net/browse/SYS-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ